### PR TITLE
add media url normalizers

### DIFF
--- a/lib/content_getters.js
+++ b/lib/content_getters.js
@@ -152,19 +152,23 @@ exports.isURLMediaAccessible = async (url, contentType) => {
  * @returns Normalized media URL
  */
 exports.normalizeMediaUrl = (mediaUrl, pageUrl) => {
-  try {
-    var uri = "";
-    const origin = new URL(pageUrl).origin;
-    if (mediaUrl?.startsWith("/")) {
-      uri = origin + mediaUrl;
-    } else if (mediaUrl?.indexOf("//") === -1) {
-      uri = `${origin}/${mediaUrl}`;
-    } else {
-      uri = mediaUrl;
+  if (mediaUrl != null) {
+    try {
+      var uri = "";
+      const origin = new URL(pageUrl).origin;
+      if (mediaUrl?.startsWith("/")) {
+        uri = origin + mediaUrl;
+      } else if (mediaUrl?.indexOf("//") === -1) {
+        uri = `${origin}/${mediaUrl}`;
+      } else {
+        uri = mediaUrl;
+      }
+      return uri;
+    } catch (error) {
+      console.log(`Error @ normalizeMediaUrl : ${error}`);
     }
-    return uri;
-  } catch (error) {
-    console.log(`Error @ normalizeMediaUrl : ${error}`);
+  } else {
+    return null;
   }
 };
 
@@ -183,19 +187,22 @@ exports.getImage = async (page) => {
     async (url, attributeName, linkAttributeName, contentType) => {
       try {
         const ogImgEl = document.querySelector("meta[property='og:image']");
-        const ogImg = ogImgEl?.getAttribute(attributeName);
+        const ogImgText = ogImgEl?.getAttribute(attributeName);
+        const ogImg = await normalizeMediaUrl(ogImgText, url);
         if (ogImg != null && (await isURLMediaAccessible(ogImg, contentType))) {
           return ogImg;
         }
 
         const twitterImgEl = document.querySelector("meta[name='twitter:image']");
-        const twitterImg = twitterImgEl?.getAttribute(attributeName);
+        const twitterImgText = twitterImgEl?.getAttribute(attributeName);
+        const twitterImg = await normalizeMediaUrl(twitterImgText, url);
         if (twitterImg != null && (await isURLMediaAccessible(twitterImg, contentType))) {
           return twitterImg;
         }
 
         const relImgLinkEl = document.querySelector("link[rel='image_src']");
-        const relImgLink = relImgLinkEl?.getAttribute(linkAttributeName);
+        const relImgLinkText = relImgLinkEl?.getAttribute(linkAttributeName);
+        const relImgLink = await normalizeMediaUrl(relImgLinkText, url);
         if (relImgLink != null && (await isURLMediaAccessible(relImgLink, contentType))) {
           return relImgLink;
         }
@@ -341,19 +348,22 @@ exports.getVideo = async (page) => {
     const video = await page.evaluate(
       async (url, contentAttribute, linkContentAttribute, contentType) => {
         const ogVideoEl = document.querySelector("meta[property='og:video']");
-        const ogVideo = ogVideoEl?.getAttribute(contentAttribute);
+        const ogVideoText = ogVideoEl?.getAttribute(contentAttribute);
+        const ogVideo = await normalizeMediaUrl(ogVideoText, url);
         if (ogVideo != null) {
           return ogVideo;
         }
 
         const twitterVideoEl = document.querySelector("meta[name='twitter:player']");
-        const twitterVideo = twitterVideoEl?.getAttribute(contentAttribute);
+        const twitterVideoText = twitterVideoEl?.getAttribute(contentAttribute);
+        const twitterVideo = await normalizeMediaUrl(twitterVideoText, url);
         if (twitterVideo != null) {
           return twitterVideo;
         }
 
         const documentVideoEl = document.querySelector("link[rel='video_src']");
-        const documentVideo = documentVideoEl?.getAttribute(linkContentAttribute);
+        const documentVideoText = documentVideoEl?.getAttribute(linkContentAttribute);
+        const documentVideo = await normalizeMediaUrl(documentVideoText, url);
         if (documentVideo != null) {
           return documentVideo;
         }
@@ -396,16 +406,16 @@ exports.getFavicon = async (page) => {
           return icon;
         }
 
-        //TODO: integrate normalizeMediaURl
-
         const shortcutIconEl = document.querySelector("link[rel='shortcut icon']");
-        const shortcutIcon = shortcutIconEl?.getAttribute(linkAttributeName);
+        const shortcutIconText = shortcutIconEl?.getAttribute(linkAttributeName);
+        const shortcutIcon = await normalizeMediaUrl(shortcutIconText, pageUrl);
         if (shortcutIcon != null && (await isURLMediaAccessible(shortcutIcon, contentType))) {
           return shortcutIcon;
         }
 
         const appleTouchIconEl = document.querySelector("link[rel='apple-touch-icon']");
-        const appleTouchIcon = appleTouchIconEl?.getAttribute(linkAttributeName);
+        const appleTouchIconText = appleTouchIconEl?.getAttribute(linkAttributeName);
+        const appleTouchIcon = await normalizeMediaUrl(appleTouchIconText, pageUrl);
         if (appleTouchIcon != null && (await isURLMediaAccessible(appleTouchIcon, contentType))) {
           return appleTouchIcon;
         }


### PR DESCRIPTION
see-link should be able to parse relative links along with links without a hostname, protocol, etc. `normalizeMediaUrl` method in `content_getters.js` will be responsible for the task.
Fixes #1

*Note:*
>  In its usage, `normalizeMediaUrl` is awaited because it was returning a `promise`. 
I don't know why :(. I have tried over on [StackOverflow](https://stackoverflow.com/q/70134434/12536629), but the issue is not resolved. Kindly open a PR if you find any solution or explanation.