### PR TITLE
configure typings to the module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "See-a-link! Get the preview metadata of the given link",
   "main": "index.js",
+  "typings": "lib/see_link.d.ts",
   "scripts": {
     "test": "mocha --timeout 5000 --exit",
     "test-server": "node ./test_setup/server"


### PR DESCRIPTION
Fixes: #7 

`typings` were already present in the module, just needed to be configured in the `package.json` file.